### PR TITLE
updated qc and facets versions

### DIFF
--- a/tools/facets.doFacets/1.6.3/facets.doFacets.cwl
+++ b/tools/facets.doFacets/1.6.3/facets.doFacets.cwl
@@ -13,7 +13,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-facets:1.6.2
+    dockerPull: mskcc/roslin-variant-facets:1.6.3
 doc: |
   Run FACETS on tumor-normal SNP read counts generated using cmo_snp-pileup
 

--- a/tools/roslin-qc/create-cdna-contam.cwl
+++ b/tools/roslin-qc/create-cdna-contam.cwl
@@ -13,7 +13,7 @@ requirements:
     ramMin: 16000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 doc: |
   None

--- a/tools/roslin-qc/create-hotspots-in-normals.cwl
+++ b/tools/roslin-qc/create-hotspots-in-normals.cwl
@@ -14,7 +14,7 @@ requirements:
     ramMin: 16000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 doc: |
   None

--- a/tools/roslin-qc/create-minor-contam-binlist.cwl
+++ b/tools/roslin-qc/create-minor-contam-binlist.cwl
@@ -14,7 +14,7 @@ requirements:
     ramMin: 16000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 doc: |
   None

--- a/tools/roslin-qc/generate-cutadapt-summary.cwl
+++ b/tools/roslin-qc/generate-cutadapt-summary.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/generate-fingerprint.cwl
+++ b/tools/roslin-qc/generate-fingerprint.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/generate-images.cwl
+++ b/tools/roslin-qc/generate-images.cwl
@@ -9,7 +9,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/generate-qual-files.cwl
+++ b/tools/roslin-qc/generate-qual-files.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/genlatex.cwl
+++ b/tools/roslin-qc/genlatex.cwl
@@ -9,7 +9,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/merge-gcbias-metrics.cwl
+++ b/tools/roslin-qc/merge-gcbias-metrics.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/merge-insert-size-histograms.cwl
+++ b/tools/roslin-qc/merge-insert-size-histograms.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/merge-picard-metrics-hsmetrics.cwl
+++ b/tools/roslin-qc/merge-picard-metrics-hsmetrics.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/merge-picard-metrics-markduplicates.cwl
+++ b/tools/roslin-qc/merge-picard-metrics-markduplicates.cwl
@@ -7,7 +7,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:

--- a/tools/roslin-qc/stitch-pdf.cwl
+++ b/tools/roslin-qc/stitch-pdf.cwl
@@ -9,7 +9,7 @@ requirements:
     ramMin: 8000
     coresMin: 1
   DockerRequirement:
-    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.2
+    dockerPull: mskcc/roslin-variant-roslin-qc:0.6.3
 
 class: CommandLineTool
 baseCommand:


### PR DESCRIPTION
Updating the roslin-qc and facets-suite versions. 
This should be used with roslin-variant 0.6.x 