### PR TITLE
Modify Xmx params being passed

### DIFF
--- a/tools/abra/2.17/abra.cwl
+++ b/tools/abra/2.17/abra.cwl
@@ -15,7 +15,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "$(runtime.tmpdir)"

--- a/tools/gatk.BaseRecalibrator/3.3-0/gatk.BaseRecalibrator.cwl
+++ b/tools/gatk.BaseRecalibrator/3.3-0/gatk.BaseRecalibrator.cwl
@@ -18,7 +18,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/gatk.DepthOfCoverage/3.3-0/gatk.DepthOfCoverage.cwl
+++ b/tools/gatk.DepthOfCoverage/3.3-0/gatk.DepthOfCoverage.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/gatk.FindCoveredIntervals/3.3-0/gatk.FindCoveredIntervals.cwl
+++ b/tools/gatk.FindCoveredIntervals/3.3-0/gatk.FindCoveredIntervals.cwl
@@ -18,7 +18,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/gatk.PrintReads/3.3-0/gatk.PrintReads.cwl
+++ b/tools/gatk.PrintReads/3.3-0/gatk.PrintReads.cwl
@@ -18,7 +18,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/gatk.mark_duplicates/4.1.0.0/gatk.mark_duplicates.cwl
+++ b/tools/gatk.mark_duplicates/4.1.0.0/gatk.mark_duplicates.cwl
@@ -171,7 +171,7 @@ arguments:
     valueFrom: '50000'
   - position: 0
     prefix: '--java-options'
-    valueFrom: '-Xms$(Math.round(parseInt(runtime.ram)/1910))G -Xmx$(Math.round(parseInt(runtime.ram)/955))G'
+    valueFrom: '-Xms$(Math.round(parseInt(runtime.ram)/1910))G -Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G'
 requirements:
   - class: ResourceRequirement
     ramMin: 32000

--- a/tools/mutect/1.1.4/mutect.cwl
+++ b/tools/mutect/1.1.4/mutect.cwl
@@ -14,7 +14,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.AddOrReplaceReadGroups/2.9/picard.AddOrReplaceReadGroups.cwl
+++ b/tools/picard.AddOrReplaceReadGroups/2.9/picard.AddOrReplaceReadGroups.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.CollectAlignmentSummaryMetrics/2.9/picard.CollectAlignmentSummaryMetrics.cwl
+++ b/tools/picard.CollectAlignmentSummaryMetrics/2.9/picard.CollectAlignmentSummaryMetrics.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.CollectGcBiasMetrics/2.9/picard.CollectGcBiasMetrics.cwl
+++ b/tools/picard.CollectGcBiasMetrics/2.9/picard.CollectGcBiasMetrics.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.CollectHsMetrics/2.9/picard.CollectHsMetrics.cwl
+++ b/tools/picard.CollectHsMetrics/2.9/picard.CollectHsMetrics.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955) - 1)G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.CollectInsertSizeMetrics/2.9/picard.CollectInsertSizeMetrics.cwl
+++ b/tools/picard.CollectInsertSizeMetrics/2.9/picard.CollectInsertSizeMetrics.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.CollectMultipleMetrics/2.9/picard.CollectMultipleMetrics.cwl
+++ b/tools/picard.CollectMultipleMetrics/2.9/picard.CollectMultipleMetrics.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"

--- a/tools/picard.MarkDuplicates/2.9/picard.MarkDuplicates.cwl
+++ b/tools/picard.MarkDuplicates/2.9/picard.MarkDuplicates.cwl
@@ -17,7 +17,7 @@ arguments:
 - valueFrom: "-Xms$(Math.round(parseInt(runtime.ram)/1910))G"
   position: 0
   shellQuote: false
-- valueFrom: "-Xmx$(Math.round(parseInt(runtime.ram)/955))G"
+- valueFrom: "-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G"
   position: 0
   shellQuote: false
 - valueFrom: "-XX:-UseGCOverheadLimit"


### PR DESCRIPTION
This was causing issues with MarkDuplicates; I think it will happen with other ones, too, that use the `-Xmx` flag to assign memory in the JVM.

There were times when the RAM allocation set in the JVM of the container/tool would be higher than what Toil allocates when it submits the job to LSF, causing LSF to kill the job. For example, given a `ramMin` setting of `80000` and `1` core, Toil takes that value, [converts it to mebibytes](https://github.com/DataBiosphere/toil/blob/89670c051803f334af625f93d058f76e2bc17201/src/toil/cwl/cwltoil.py#L549) and performs a calculation that results in a Toil memory assignment of `78 G` (based on the algorithm [here](https://github.com/DataBiosphere/toil/blob/releases/3.21.0/src/toil/batchSystems/lsf.py#L163-L171)). 

That `78 G` value doesn't get passed to the JVM, though, because and it does [its own calculation here](https://github.com/mskcc/roslin-cwl/compare/master...bugfix/mem_reqs_for_jvm_params#diff-1052a926f8dbe765c15bf9e44ae58456L20).

```
-Xmx$(Math.round(parseInt(runtime.ram)/955))G
```

 Because of this, it takes the original value - `80000` - and divides it by `955`, which ends up with a RAM `-Xmx` allocation of `>83 GB`, larger than the `78 GB` LSF was instructed to expect. LSF then kills these jobs whenever it goes higher than `78 GB`.

I've converted it to do 
```
-Xmx$(Math.floor(parseInt(runtime.ram)/1048) - 1)G
```
... so that it's lower than the value Toil submits the job for, with a `- 1` just in case. The `1048` value in the denominator can be set to `1024`, but again I changed it to a slightly higher number just in case.

I've changed all `Math.round()` calls to `Math.floor()`, too, because apparently with `Math.round()` there's danger of rounding up.